### PR TITLE
Changed uid and guid mapping

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,6 @@
 int main(int argc, char *argv[])
 {
 	int option = 0;
-	char **child_entrypoint;
 	bool empty = false;
 	bool runall = false;
 	bool pids_flag = false;
@@ -24,6 +23,7 @@ int main(int argc, char *argv[])
 	long max_weight = 0;
 	long cpu_shares = 0;
 	long memory_limit = 0;
+	char **child_entrypoint;
 	struct runc_args *runc_arguments = NULL;
 	struct cgroup_args *cgroup_arguments = NULL;
 
@@ -185,9 +185,9 @@ int main(int argc, char *argv[])
 
 usage:
 	printf("Usage: sudo ./MyDocker <options> <entrypoint>\n");
-    printf("\n");
-    printf("<options> should be:\n");
-    printf("\t- a\trun all namespaces without the user namespace\n");
+	printf("\n");
+	printf("<options> should be:\n");
+	printf("\t- a\trun all namespaces without the user namespace\n");
 	printf("\t- U\trun a user namespace using unprivileged container\n");
 	printf("\t- c\tcgrops used to limit resources.\n\t\tThis command must "
 	"be chained with at least one of:\n");

--- a/src/namespaces/user/user.c
+++ b/src/namespaces/user/user.c
@@ -19,13 +19,13 @@ void map_uid_gid(pid_t child_pid) {
     char map_buf[MAX_BUF_SIZE];
 
     snprintf(map_path, PATH_MAX, "/proc/%ld/uid_map", (long) child_pid);
-    snprintf(map_buf, MAX_BUF_SIZE, "0 1000 1");
+    snprintf(map_buf, MAX_BUF_SIZE, "0 100000 65536");
     uid_map = map_buf;
     update_map(uid_map, map_path);
 
     proc_setgroups_write(child_pid, "deny");
     snprintf(map_path, PATH_MAX, "/proc/%ld/gid_map",(long) child_pid);
-    snprintf(map_buf, MAX_BUF_SIZE, "0 1000 1");
+    snprintf(map_buf, MAX_BUF_SIZE, "0 100000 65536");
     gid_map = map_buf;
     update_map(gid_map, map_path);
 }

--- a/src/runc.c
+++ b/src/runc.c
@@ -29,7 +29,7 @@ int child_fn(void *args_par)
     struct clone_args *args = (struct clone_args *) args_par;
     char ch;
     
-    if(args->has_userns){
+    if (args->has_userns) {
 	    /* We are the consumer*/
 	    close(args->sync_uid_gid_map_fd[1]);
 
@@ -38,16 +38,16 @@ int child_fn(void *args_par)
 		    fprintf(stderr, "Failure in child: read from pipe returned != 0\n");
 		    exit(EXIT_FAILURE);
 	    }
-	   close(args->sync_uid_gid_map_fd[0]);
+	    close(args->sync_uid_gid_map_fd[0]);
            
-	   /* UID 0 maps to UID 1000 outside. Ensure that the exec process
-            * will run as UID 0 in order to drop its privileges */
-    	   if (setresgid(0,0,0) == -1)
-		    printErr("Failed to setgid.\n");
-	   if (setresuid(0,0,0) == -1)
-		    printErr("Failed to setuid.\n");
+        /* UID 0 maps to UID 1000 outside. Ensure that the exec process
+         * will run as UID 0 in order to drop its privileges */
+        if (setresgid(0,0,0) == -1)
+            printErr("setgid");
+        if (setresuid(0,0,0) == -1)
+            printErr("setuid");
 
-	   fprintf(stderr,"=> setuid and seguid done.\n");	  
+        fprintf(stderr,"=> setuid and seguid done\n");	  
     }
 
     /* setting new hostname */

--- a/src/runc.c
+++ b/src/runc.c
@@ -95,6 +95,7 @@ int child_fn(void *args_par)
     * the real host root, so drop some capablities */
     drop_caps();
 
+    /* disallowing system calls using seccomp */
     sys_filter();
       
     if (execvp(args->command[0], args->command) != 0)

--- a/src/runc.c
+++ b/src/runc.c
@@ -173,10 +173,9 @@ void runc(struct runc_args *runc_arguments)
                 CLONE_NEWUTS 	|
                 CLONE_NEWIPC 	|
                 CLONE_NEWPID 	|
-                CLONE_NEWNET
-		;
+                CLONE_NEWNET;
     
-    /* add CLONE_NEWGROUP if required */
+    /* CLONE_NEWGROUP if required */
     if (runc_arguments->resources) {
         clone_flags |= CLONE_NEWCGROUP;
         args.resources = runc_arguments->resources;
@@ -185,11 +184,12 @@ void runc(struct runc_args *runc_arguments)
         apply_cgroups(args.resources);
     }
 
+    /* CLONE_NEWUSER if required */
     if (runc_arguments->has_userns)
 	    clone_flags |= CLONE_NEWUSER;
 
     child_pid = clone(child_fn, child_stack + STACK_SIZE,
-            	      clone_flags | SIGCHLD, &args);
+                        clone_flags | SIGCHLD, &args);
 
     if (child_pid < 0) {
         free_cgroup_resources();


### PR DESCRIPTION
As described in [this LXD blog](https://ubuntu.com/blog/custom-user-mappings-in-lxd-containers), it is better to map the uid to a value like 100000 and let the lenght equal to 65536 in order to be POSIX compliant. Actually it is necessary to change the ownership of the `root_fs` folder to allows the containered process to write inside it.
`sudo chown -R 100000:100000 root_fs`
This solution should be fixed using a real root fs image for the new process.