### PR TITLE
New capabilities runc compliant. Some oh them are taken by Lizzie Dixon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ AUX_SOURCE_DIRECTORY(./src/namespaces/cgroup/ MyDocker_SRC_namespaces_cgroup)
 # Set seccomp source directory
 AUX_SOURCE_DIRECTORY(./src/seccomp/ MyDocker_SRC_seccomp)
 
+# Set capabilities source directory
+AUX_SOURCE_DIRECTORY(./src/capabilities MyDocker_SRC_capabilities)
+
 # Create executable
 ADD_EXECUTABLE(
 	MyDocker
@@ -32,6 +35,7 @@ ADD_EXECUTABLE(
 	${MyDocker_SRC_namespaces_network}
 	${MyDocker_SRC_namespaces_cgroup}
 	${MyDocker_SRC_seccomp}
+	${MyDocker_SRC_capabilities}
 )
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/src/capabilities/capabilities.c
+++ b/src/capabilities/capabilities.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#include "capabilities.h"
+#include "../helpers/helpers.h"
+
+int drop_caps()
+{
+	fprintf(stderr, "=> dropping capabilities...");
+    int drop_caps[] = {
+        CAP_NET_BROADCAST,
+        CAP_SYS_MODULE,
+        CAP_SYS_RAWIO,
+        CAP_SYS_PACCT,
+        CAP_SYS_ADMIN,
+        CAP_SYS_NICE,
+        CAP_SYS_RESOURCE,
+        CAP_SYS_TIME,
+        CAP_SYS_TTY_CONFIG,
+        CAP_AUDIT_CONTROL,
+        CAP_MAC_OVERRIDE,
+        CAP_MAC_ADMIN,
+        CAP_NET_ADMIN,
+        CAP_SYSLOG,
+        CAP_DAC_READ_SEARCH,
+        CAP_LINUX_IMMUTABLE,
+        CAP_IPC_LOCK,
+        CAP_IPC_OWNER,
+        CAP_SYS_PTRACE,
+        CAP_SYS_BOOT,
+        CAP_LEASE,
+        CAP_WAKE_ALARM,
+        CAP_BLOCK_SUSPEND,
+        CAP_MKNOD,
+        CAP_AUDIT_READ,
+        CAP_AUDIT_WRITE,
+        CAP_FSETID,
+        CAP_SETFCAP
+	};
+
+	size_t num_caps = sizeof(drop_caps) / sizeof(*drop_caps);
+	fprintf(stderr, "bounding...");
+	
+    for (size_t i = 0; i < num_caps; i++) {
+		if (prctl(PR_CAPBSET_DROP, drop_caps[i], 0, 0, 0)) {
+			printErr("prctl");
+		}
+	}
+
+	fprintf(stderr, "inheritable...");
+    cap_t caps = NULL;
+
+	if (!(caps = cap_get_proc())
+	    || cap_set_flag(caps, CAP_INHERITABLE, num_caps, drop_caps, CAP_CLEAR)
+	    || cap_set_proc(caps)) {
+		if (caps) cap_free(caps);
+        printErr("inheritable");
+    }
+	cap_free(caps);
+	fprintf(stderr, "done.\n");
+}

--- a/src/capabilities/capabilities.h
+++ b/src/capabilities/capabilities.h
@@ -1,0 +1,2 @@
+/* dropping capailities */
+int drop_caps();

--- a/src/namespaces/user/user.c
+++ b/src/namespaces/user/user.c
@@ -7,8 +7,6 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <string.h>
-#include <sys/capability.h>
-#include <sys/prctl.h>
 #include "../../helpers/helpers.h"
 #include "user.h"
 
@@ -86,52 +84,4 @@ void proc_setgroups_write(pid_t child_pid, char *str) {
             strerror(errno));
 
     close(fd);
-}
-
-int drop_caps(){
-
-	fprintf(stderr, "=> dropping capabilities...");
-	int drop_caps[] = {
-		CAP_AUDIT_CONTROL,
-		CAP_AUDIT_READ,
-		CAP_AUDIT_WRITE,
-		CAP_BLOCK_SUSPEND,
-		CAP_DAC_READ_SEARCH,
-		CAP_FSETID,
-		CAP_IPC_LOCK,
-		CAP_MAC_ADMIN,
-		CAP_MAC_OVERRIDE,
-		CAP_MKNOD,
-		CAP_SETFCAP,
-		CAP_SYSLOG,
-		CAP_SYS_ADMIN,
-		CAP_SYS_BOOT,
-		CAP_SYS_MODULE,
-		CAP_SYS_NICE,
-		CAP_SYS_RAWIO,
-		CAP_SYS_RESOURCE,
-		CAP_SYS_TIME,
-		CAP_WAKE_ALARM
-	};
-	size_t num_caps = sizeof(drop_caps) / sizeof(*drop_caps);
-	fprintf(stderr, "bounding...");
-	for (size_t i = 0; i < num_caps; i++) {
-		if (prctl(PR_CAPBSET_DROP, drop_caps[i], 0, 0, 0)) {
-			fprintf(stderr, "prctl failed: %m\n");
-			return 1;
-		}
-	}
-	fprintf(stderr, "inheritable...");
-	cap_t caps = NULL;
-	if (!(caps = cap_get_proc())
-	    || cap_set_flag(caps, CAP_INHERITABLE, num_caps, drop_caps, CAP_CLEAR)
-	    || cap_set_proc(caps)) {
-		fprintf(stderr, "failed: %m\n");
-		if (caps) cap_free(caps);
-		return 1;
-	}
-	cap_free(caps);
-	fprintf(stderr, "done.\n");
-	return 0;
-
 }

--- a/src/namespaces/user/user.h
+++ b/src/namespaces/user/user.h
@@ -79,6 +79,3 @@ void update_map(char *mapping, char *map_file);
  * purpose of the following function.
  */
 void proc_setgroups_write(pid_t child_pid, char *str);
-
-
-int drop_caps();

--- a/src/runc.c
+++ b/src/runc.c
@@ -15,13 +15,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "runc.h"
+#include "../config.h"
 #include "helpers/helpers.h"
 #include "namespaces/user/user.h"
 #include "namespaces/mount/mount.h"
+#include "seccomp/seccomp_config.h"
 #include "namespaces/cgroup/cgroup.h"
+#include "capabilities/capabilities.h"
 #include "namespaces/network/network.h"
-#include "../config.h"
-#include "./seccomp/seccomp_config.h"
 
 
 int child_fn(void *args_par)
@@ -91,6 +92,7 @@ int child_fn(void *args_par)
     perform_pivot_root(args->has_userns);
 
     prepare_dev_fd();
+
    /* The root user inside the container must have less privileges than
     * the real host root, so drop some capablities */
     drop_caps();


### PR DESCRIPTION
This PR will add a new set of capabilities to drop for the containered process. In particular these caps are taken from [runc specification](https://github.com/opencontainers/runc/blob/master/libcontainer/SPEC.md) but merged with [lizzie's ones](https://blog.lizzie.io/linux-containers-in-500-loc.html). \
A more restrictive decision was taken in order to add a strictly security profile. \
Moreover this part has been moved from `user.c` to `capabilities.c`. A new capabilities folder has already added.